### PR TITLE
Updated pom - Added geotools repo. Added compiler plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+        <repository>
+            <id>geotools</id>
+            <url>http://download.osgeo.org/webdav/geotools</url>
+        </repository>
+    </repositories>
+
     <groupId>groupId</groupId>
     <artifactId>geomesa-quickstart</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -62,6 +69,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
Before adding repository, this error was occurring:

[ERROR] Failed to execute goal on project geomesa-quickstart: Could not resolve dependencies for project groupId:geomesa-quickstart:jar:1.0-SNAPSHOT: The following artifacts could not be resolved: org.geotools:gt-opengis:jar:11.2, org.geotools:gt-data:jar:11.2, org.geotools:gt-epsg-hsql:jar:11.2: Failure to find org.geotools:gt-opengis:jar:11.2 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]

After adding repository but before adding the compiler plugin, these errors were showing up:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project geomesa-quickstart: Compilation failure: Compilation failure:
[ERROR] /home/tim/workspace/geomesa-quickstart/src/main/java/org/geomesa/QuickStart.java:[111,12] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/tim/workspace/geomesa-quickstart/src/main/java/org/geomesa/QuickStart.java:[113,22] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/tim/workspace/geomesa-quickstart/src/main/java/org/geomesa/QuickStart.java:[267,20] error: ';' expected
[ERROR] -> [Help 1]

These additions are already found in the pom.xml in the geomesa repository.
